### PR TITLE
fix: set env failed bug. 

### DIFF
--- a/common/helpers.php
+++ b/common/helpers.php
@@ -48,7 +48,9 @@ function redirect($url, $statusCode = 302)
 function env($key, $default = null)
 {
 
-    $value = getenv($key) ?? $_ENV[$key] ?? $_SERVER[$key];
+    if (!$value = getenv($key)) {
+        $value = $_ENV[$key] ?? $_SERVER[$key];
+    }
 
     if ($value === false) {
         return $default;

--- a/common/helpers.php
+++ b/common/helpers.php
@@ -49,7 +49,7 @@ function env($key, $default = null)
 {
 
     if (!$value = getenv($key)) {
-        $value = $_ENV[$key] ?? $_SERVER[$key];
+        $value = isset($_ENV[$key]) ? $_ENV[$key] : (isset($_SERVER[$key]) ? $_SERVER[$key] : null);
     }
 
     if ($value === false) {


### PR DESCRIPTION
When getenv() return false, the $value is false

```$value = getenv($key) ?? $_ENV[$key] ?? $_SERVER[$key];```