### PR TITLE
Fix article datetimepicker format

### DIFF
--- a/backend/modules/content/views/article/_form.php
+++ b/backend/modules/content/views/article/_form.php
@@ -77,7 +77,7 @@ use rmrevin\yii\fontawesome\FAS;
                     [
                         'type' => DateTimePicker::TYPE_INLINE,
                         'pluginOptions' => [
-                            'format' => 'yyyy-mm-dd HH:mm:ss',
+                            'format' => 'yyyy-mm-dd hh:ii',
                             'showMeridian' => true,
                             'todayBtn' => true,
                         ]


### PR DESCRIPTION
Old format `yyyy-mm-dd HH:mm:ss` was showing twice the month and hour in 12 hours format.
Now replaced by `yyyy-mm-dd hh:ii`.